### PR TITLE
Add support for disabling builtin `SentryLogger`

### DIFF
--- a/osu.Game.Rulesets.AuthlibInjection/AuthlibInjectionRuleset.cs
+++ b/osu.Game.Rulesets.AuthlibInjection/AuthlibInjectionRuleset.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -10,6 +11,7 @@ using osu.Game.Configuration;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.AuthlibInjection.Beatmaps;
 using osu.Game.Rulesets.AuthlibInjection.Configuration;
+using osu.Game.Rulesets.AuthlibInjection.Patches;
 using osu.Game.Rulesets.AuthlibInjection.UI;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
@@ -81,6 +83,13 @@ namespace osu.Game.Rulesets.AuthlibInjection
                         Icon = FontAwesome.Solid.Hammer,
                     }
                 ];
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuGame game)
+            {
+                if (GlobalConfigManager.Config.DisableSentryLogger)
+                    DisableSentryPatch.Run(game);
             }
         }
     }

--- a/osu.Game.Rulesets.AuthlibInjection/Configuration/AuthlibRulesetConfig.cs
+++ b/osu.Game.Rulesets.AuthlibInjection/Configuration/AuthlibRulesetConfig.cs
@@ -12,7 +12,8 @@ public class AuthlibRulesetConfig
         string spectatorUrl,
         string multiplayerUrl,
         string metadataUrl,
-        string beatmapSubmissionServiceUrl)
+        string beatmapSubmissionServiceUrl,
+        bool disableSentryLogger)
     {
         ApiUrl = removeSuffix(apiUrl, "/");
         WebsiteUrl = removeSuffix(websiteUrl, "/");
@@ -22,6 +23,7 @@ public class AuthlibRulesetConfig
         MultiplayerUrl = removeSuffix(multiplayerUrl, "/");
         MetadataUrl = removeSuffix(metadataUrl, "/");
         BeatmapSubmissionServiceUrl = removeSuffix(beatmapSubmissionServiceUrl, "/");
+        DisableSentryLogger = disableSentryLogger;
     }
 
     public string ApiUrl { get; set; } = string.Empty;
@@ -32,6 +34,8 @@ public class AuthlibRulesetConfig
     public string MultiplayerUrl { get; set; } = string.Empty;
     public string MetadataUrl { get; set; } = string.Empty;
     public string BeatmapSubmissionServiceUrl { get; set; } = string.Empty;
+
+    public bool DisableSentryLogger { get; set; } = true;
 
     private static string removeSuffix(string text, string suffix)
     {

--- a/osu.Game.Rulesets.AuthlibInjection/Configuration/AuthlibRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.AuthlibInjection/Configuration/AuthlibRulesetConfigManager.cs
@@ -19,6 +19,7 @@ public class AuthlibRulesetConfigManager(SettingsStore store, RulesetInfo rulese
         SetDefault(AuthlibRulesetSettings.MultiplayerUrl, string.Empty);
         SetDefault(AuthlibRulesetSettings.MetadataUrl, string.Empty);
         SetDefault(AuthlibRulesetSettings.BeatmapSubmissionServiceUrl, string.Empty);
+        SetDefault(AuthlibRulesetSettings.DisableSentryLogger, true);
     }
 }
 
@@ -31,5 +32,6 @@ public enum AuthlibRulesetSettings
     SpectatorUrl,
     MultiplayerUrl,
     MetadataUrl,
-    BeatmapSubmissionServiceUrl
+    BeatmapSubmissionServiceUrl,
+    DisableSentryLogger,
 }

--- a/osu.Game.Rulesets.AuthlibInjection/Configuration/GlobalConfigManager.cs
+++ b/osu.Game.Rulesets.AuthlibInjection/Configuration/GlobalConfigManager.cs
@@ -40,7 +40,14 @@ public class GlobalConfigManager
             string val = split.Length > 1 ? split[1] : string.Empty;
             if (string.IsNullOrEmpty(val))
             {
-                continue;
+                switch (key)
+                {
+                    case "--disable-sentry-logger":
+                        config.DisableSentryLogger = true;
+                        continue;
+                    default:
+                        continue;
+                }
             }
 
             if (!val.StartsWith("http://") && !val.StartsWith("https://"))

--- a/osu.Game.Rulesets.AuthlibInjection/Patches/DisableSentryPatch.cs
+++ b/osu.Game.Rulesets.AuthlibInjection/Patches/DisableSentryPatch.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Logging;
+using osu.Game.Utils;
+
+namespace osu.Game.Rulesets.AuthlibInjection.Patches
+{
+    public static class DisableSentryPatch
+    {
+        private const BindingFlags instance_flag = BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.GetProperty | BindingFlags.GetField;
+
+        /// <summary>
+        /// Dispose the Sentry telemetry logger.
+        /// </summary>
+        /// <param name="game">The <see cref="OsuGame"/> instance where the logger exists.</param>
+        /// <remarks>Most of this workaround comes from
+        /// https://github.com/MATRIX-feather/LLin/blob/ruleset/osu.Game.Rulesets.Hikariii/Features/ListenerLoader/Handlers/SentryLoggerDisabler.cs</remarks>
+        public static void Run(OsuGame game)
+        {
+            try
+            {
+                var field = game.GetType().GetFields(instance_flag)
+                    .FirstOrDefault(f => f.FieldType == typeof(SentryLogger));
+
+                if (field == null)
+                {
+                    Logger.Log("Cannot find SentryLogger. It might have been disposed.");
+                    return;
+                }
+
+                object val = field.GetValue(game);
+                if (val is not SentryLogger sentryLogger)
+                    throw new Exception($"Type mismatch: expect SentryLogger, got {val?.GetType()}.");
+
+                sentryLogger.Dispose();
+                Logger.Log("SentryLogger has been disposed successfully.");
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to disable sentry logger.");
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.AuthlibInjection/UI/AuthlibSettingsSubsection.cs
+++ b/osu.Game.Rulesets.AuthlibInjection/UI/AuthlibSettingsSubsection.cs
@@ -14,6 +14,7 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.AuthlibInjection.Configuration;
+using osu.Game.Rulesets.AuthlibInjection.Patches;
 
 namespace osu.Game.Rulesets.AuthlibInjection.UI;
 
@@ -21,35 +22,32 @@ public partial class AuthlibSettingsSubsection(Ruleset ruleset) : RulesetSetting
 {
     private const int delay = 1500;
     private readonly Ruleset ruleset = ruleset;
-
-    // ReSharper disable once InconsistentNaming
-    private SettingsTextBox ApiUrl = null!;
-
     private AuthlibRulesetConfig authlibRulesetConfig = new();
 
-    // ReSharper disable once InconsistentNaming
+    // Considered for distinction, batch disabling
+    // ReSharper disable InconsistentNaming
+    private SettingsCheckbox DisableSentryLogging = null!;
+
+    private SettingsTextBox ApiUrl = null!;
+
     private SettingsTextBox BeatmapSubmissionServiceUrl = null!;
 
-    // ReSharper disable once InconsistentNaming
     private SettingsTextBox ClientId = null!;
 
-    // ReSharper disable once InconsistentNaming
     private SettingsTextBox ClientSecret = null!;
+
+    private SettingsTextBox MetadataUrl = null!;
+
+    private SettingsTextBox MultiplayerUrl = null!;
+
+    private SettingsTextBox SpectatorUrl = null!;
+
+    private SettingsTextBox WebsiteUrl = null!;
+    // ReSharper restore InconsistentNaming
 
     private string filePath = "";
     private int isInitialLoading;
 
-    // ReSharper disable once InconsistentNaming
-    private SettingsTextBox MetadataUrl = null!;
-
-    // ReSharper disable once InconsistentNaming
-    private SettingsTextBox MultiplayerUrl = null!;
-
-    // ReSharper disable once InconsistentNaming
-    private SettingsTextBox SpectatorUrl = null!;
-
-    // ReSharper disable once InconsistentNaming
-    private SettingsTextBox WebsiteUrl = null!;
     [CanBeNull] private ScheduledDelegate writeToFile;
 
     private AuthlibRulesetConfigManager config => (AuthlibRulesetConfigManager)Config;
@@ -62,7 +60,7 @@ public partial class AuthlibSettingsSubsection(Ruleset ruleset) : RulesetSetting
 
 
     [BackgroundDependencyLoader]
-    private void load(Storage storage)
+    private void load(OsuGame game, Storage storage)
     {
         filePath = storage.GetFullPath(AuthlibRulesetConfig.CONFIG_FILE_NAME);
         if (File.Exists(filePath))
@@ -113,6 +111,12 @@ public partial class AuthlibSettingsSubsection(Ruleset ruleset) : RulesetSetting
             {
                 LabelText = "Beatmap Submission Service Url",
                 Current = config.GetBindable<string>(AuthlibRulesetSettings.BeatmapSubmissionServiceUrl)
+            },
+            DisableSentryLogging = new SettingsCheckbox()
+            {
+                LabelText = "Disable Sentry Logger",
+                TooltipText = "Stop sending telemetry error data to the osu! dev team.",
+                Current = config.GetBindable<bool>(AuthlibRulesetSettings.DisableSentryLogger)
             }
         ];
         isInitialLoading = Children.Count;
@@ -132,6 +136,18 @@ public partial class AuthlibSettingsSubsection(Ruleset ruleset) : RulesetSetting
             onCustomApiUrlChanged(MetadataUrl, nameof(MetadataUrl), e), true);
         BeatmapSubmissionServiceUrl.Current.BindValueChanged(e =>
             onCustomApiUrlChanged(BeatmapSubmissionServiceUrl, nameof(BeatmapSubmissionServiceUrl), e), true);
+        DisableSentryLogging.Current.BindValueChanged(e => onSentryOptOutChanged(e, game), true);
+    }
+
+    private void onSentryOptOutChanged(ValueChangedEvent<bool> e, OsuGame game)
+    {
+        File.WriteAllText(filePath, JsonConvert.SerializeObject(authlibRulesetConfig));
+
+        // When switching from off to on, try to disable potentially active logger instance.
+        if (e.NewValue)
+        {
+            DisableSentryPatch.Run(game);
+        }
     }
 
     private void onCustomApiUrlChanged(SettingsTextBox input, string from, ValueChangedEvent<string> e)


### PR DESCRIPTION
This PR added a setting to disable the Sentry Logger on injection, which is enabled by default.
